### PR TITLE
Fixed Typo and Javascript console error

### DIFF
--- a/library/p5.spacebrew.js
+++ b/library/p5.spacebrew.js
@@ -170,14 +170,14 @@ var Spacebrew = function () {
 	}
 
 	/**
-	 * Add a listener to the 'onStringMessgae' event
+	 * Add a listener to the 'onStringMessage' event
 	 * @param  {Function} fxn Function following this format: 
 	 *                      function NAME_OF_FUNCTION( name, value ){}
 	 * @return {Spacebrew}
 	 */
-	this.onStringMessgae = function( fxn ){
+	this.onStringMessage = function( fxn ){
 	    var f = function (e) { fxn(e.detail.name, e.detail.value); };
-		document.addEventListener('onStringMessgae', f, false);
+		document.addEventListener('onStringMessage', f, false);
 		return this;
 	}
 

--- a/library/p5.spacebrew.js
+++ b/library/p5.spacebrew.js
@@ -365,8 +365,8 @@ var Spacebrew = function () {
 			var onRangeMessageEvent 	= new CustomEvent('onRangeMessage', {detail:{name:m.name, value:m.value}});
 			document.dispatchEvent( onRangeMessageEvent  );
 		} else {
-			var onCustomMessageEvent 	= new CustomEvent('onRangeMessage', {detail:{name:m.name, type:type, value:m.value}});
-			document.dispatchEvent( onRangeMessageEvent  );
+			var onCustomMessageEvent 	= new CustomEvent('onCustomMessage', {detail:{name:m.name, type:type, value:m.value}});
+			document.dispatchEvent( onCustomMessageEvent  );
 		}
 	}
 


### PR DESCRIPTION
Was getting 'Uncaught InvalidStateError: Failed to execute 'dispatchEvent' on 'EventTarget': The event provided is null.' in the console when relaying custom messages, fixing custom message event to the correct names fixed it.

Also fixed 'messgae' typo.
